### PR TITLE
Add a pre-populated Spring Initializr link

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -20,6 +20,9 @@ include::https://raw.githubusercontent.com/spring-guides/getting-started-macros/
 [[scratch]]
 == Starting with Spring Initializr
 
+If you like, you can use this https://start.spring.io/#!type=maven-project&language=java&packaging=jar&jvmVersion=17&groupId=com.example&artifactId=graphqlserver&name=graphqlserver&description=Demo%20project%20for%20Spring%20Boot&packageName=com.example.graphqlserver[pre-populated Spring Initializr link] to load the correct settings.
+Otherwise, continue on to manually set up the Initializr.
+
 To manually initialize the project:
 
 . Navigate to https://start.spring.io.


### PR DESCRIPTION
as a convenience and to get the package name created by the Initializr to match the code in the complete and initial projects.